### PR TITLE
1.4.1test

### DIFF
--- a/test/functional/bio/test_command.rb
+++ b/test/functional/bio/test_command.rb
@@ -98,7 +98,10 @@ module Bio
       else
         @sort = "/usr/bin/sort"
         unless FileTest.executable?(@sort) then
-          raise "Unsupported environment: /usr/bin/sort not found"
+          @sort = "/bin/sort"
+          unless FileTest.executable?(@sort) then
+            raise "Unsupported environment: /usr/bin/sort nor /bin/sort not found"
+          end
         end
         @data = @data.join("\n") + "\n"
       end


### PR DESCRIPTION
The command sort may not exist in /usr/bin but in /bin, which is the case in CentOS.
Checking for /bin/sort will not be too harmful.
Checking for all the PATH places might be another right way, though some non-standard
command may be invoked by that.

So, as a conservative solution, this patch checks /bin/sort after failing to find /usr/bin/sort
