### PR TITLE
Very minor fix in Bio::Sequence method_missing

### DIFF
--- a/lib/bio/sequence.rb
+++ b/lib/bio/sequence.rb
@@ -102,7 +102,7 @@ class Sequence
   # http://www.rubycentral.com/book/ref_c_object.html#Object.method_missing
   def method_missing(sym, *args, &block) #:nodoc:
     begin
-      seq.__send__(sym, *args, &block)
+      @seq.__send__(sym, *args, &block)
     rescue NoMethodError => evar
       lineno = __LINE__ - 2
       file = __FILE__


### PR DESCRIPTION
Minor fix - Bio::Sequence was sending method missing requests to a nil object rather than the seq instance variable.

I'm pretty sure that seq string object was supposed to have the first go at recieving the unidentified method symbols. I'm making this assumption on observations of the behaviour of [bio/sequence/format.rb](https://github.com/bioruby/bioruby/blob/master/lib/bio/sequence/format.rb#L126), where the sequence object (String) is the first port of call for unknown methods.
