### PR TITLE
Accept uppercase codons when setting or getting in Bio::CodonTable.

### DIFF
--- a/lib/bio/data/codontable.rb
+++ b/lib/bio/data/codontable.rb
@@ -91,7 +91,7 @@ class CodonTable
   # Translate a codon into a relevant amino acid.  This method is used for
   # translating a DNA sequence into amino acid sequence.
   def [](codon)
-    @table[codon]
+    @table[codon.downcase]
   end
 
   # Modify the codon table.  Use with caution as it may break hard coded
@@ -107,7 +107,7 @@ class CodonTable
   #   table['tga'] = 'U'
   #
   def []=(codon, aa)
-    @table[codon] = aa
+    @table[codon.downcase] = aa
   end
 
   # Iterates on codon table hash.

--- a/test/unit/bio/data/test_codontable.rb
+++ b/test/unit/bio/data/test_codontable.rb
@@ -80,6 +80,16 @@ module Bio
       @ct['atg'] = 'M'
       assert_equal('M', @ct['atg'])
     end
+    
+    def test_set_uppercase_accessor #[]=
+      assert_equal('Q', @ct['CAG'])
+      alternative = 'Y'
+      @ct['CAG'] = alternative
+      assert_equal(alternative, @ct['cag'])
+      @ct['cag'] = 'Q'
+      assert_equal('Q', @ct['cag'])
+      assert_equal('Q', @ct['CAG'])
+    end
 
     def test_each
       assert(@ct.each {|x| })


### PR DESCRIPTION
Previously it was possible to set codons in uppercase in the internal hash, but they had no effect on translation as the lowercase version was also kept and that was used. So if you didn't read the example code properly and used uppercase definition for the codons, you might waste a few minutes working out why the Sequence::NA wasn't translating with the modified translation table (happened to a friend of mine, let's say).
