### PR TITLE
Some unit test fixes.

### DIFF
--- a/lib/bio/db/gff.rb
+++ b/lib/bio/db/gff.rb
@@ -1231,7 +1231,9 @@ module Bio
             attr_reader :code if false #dummy for RDoc
 
             # length (Integer)
-            attr_reader :length if false #dummy for RDoc
+            def length
+                self[:length]
+            end
  
             def to_s
               "#{code}#{length}"

--- a/test/unit/bio/db/test_soft.rb
+++ b/test/unit/bio/db/test_soft.rb
@@ -90,7 +90,7 @@ module Bio #:nodoc:
       assert_equal( @obj_dataset.database[:institute], 'NCBI NLM NIH')
 
       assert_equal( @obj_dataset.subsets.size, 8)
-      assert_equal( @obj_dataset.subsets.keys, ["GDS100_1",
+      assert_equal( @obj_dataset.subsets.keys.sort, ["GDS100_1",
        "GDS100_2",
        "GDS100_3",
        "GDS100_4",


### PR DESCRIPTION
First fix is for test/unit/bio/db/test_soft.rb. It didn't sort hash keys before comparison whereas they are not necessarily ordered in different Rubies.

Second one is for lib/bio/db/gff.rb. It uses Struct with length field, but Struct already has method 'length' (http://www.ruby-doc.org/core-1.9.3/Struct.html#method-i-length). So clash of names occurs. For instance, Rubinius always returns 2, i.e. number of fields.

By the way, Rubinius from trunk passes all tests in 1.8 mode, with these changes. Recently a bug in String#split was fixed (https://github.com/rubinius/rubinius/issues/1693) which caused problems with test_nbrf.rb. The fix is not in 2.0-testing branch yet, so I expect Travis CI to become aware of the fix in next 1-3 weeks.
