### PR TITLE
Use libxml-ruby instead of libxml-jruby to fix JRuby test failures.

### DIFF
--- a/gemfiles/Gemfile.travis-jruby1.8
+++ b/gemfiles/Gemfile.travis-jruby1.8
@@ -2,5 +2,5 @@ source :rubygems
 
 gem "rake"
 
-gem "libxml-jruby"
+gem "libxml-ruby"
 

--- a/gemfiles/Gemfile.travis-jruby1.9
+++ b/gemfiles/Gemfile.travis-jruby1.9
@@ -2,7 +2,7 @@ source :rubygems
 
 gem "rake"
 
-gem "libxml-jruby"
+gem "libxml-ruby"
 
 ## disabled because of "uninitialized constant XML::SaxParser" error
 #gem "soap4r-ruby1.9"


### PR DESCRIPTION
The travis-ci Gemfiles currently call for libxml-jruby; this appears
not to support the same API as libxml-ruby, resulting in several tests
in test/unit/bio/db/test_phyloxml.rb failing with "NameError:
uninitialized constant LibXMLJRuby::XML::Parser::Options". Switching
to the C libxml-ruby library allows these tests to pass under JRuby in
1.8 mode.

JRuby in 1.9 mode still fails a few PhyloXML tests due to
https://jira.codehaus.org/browse/JRUBY-6662.
