### PR TITLE
broader Fastq file recognition

### DIFF
--- a/lib/bio/io/flatfile/autodetection.rb
+++ b/lib/bio/io/flatfile/autodetection.rb
@@ -482,7 +482,7 @@ module Bio
             /^seq1 \= .*\, \d+ bp(\r|\r?\n)seq2 \= .*\, \d+ bp(\r|\r?\n)/ ],
 
           fastq  = RuleRegexp[ 'Bio::Fastq',
-            /^\@.+(?:\r|\r?\n)(?:[^\@\+].*(?:\r|\r?\n))+\+.*(?:\r|\r?\n).+(?:\r|\r?\n)/ ],
+            /^\@.+(?:\r|\r?\n)(?:[^\@\+].*(?:\r|\r?\n))+/ ],
 
           fastaformat = RuleProc.new('Bio::FastaFormat',
                                      'Bio::NBRF',

--- a/test/unit/bio/io/flatfile/test_autodetection.rb
+++ b/test/unit/bio/io/flatfile/test_autodetection.rb
@@ -347,6 +347,12 @@ __END_OF_TEXT__
 #    def test_sim4
 #    end
 
+    def test_fastq
+      fn = File.join(TestDataPath, 'fastq', 'longreads_original_sanger.fastq')
+      text = File.read(fn, length=300)
+      assert_equal(Bio::Fastq, @ad.autodetect(text))
+    end
+
     def test_fastaformat
       fn = File.join(TestDataPath, 'fasta', 'example1.txt')
       text = File.read(fn)


### PR DESCRIPTION
An example patch for the Issue #57 https://github.com/bioruby/bioruby/issues/57

Please note that PacBio may produce kilobases long reads and the 31 lines may not be sufficient to find the second id line starting with '+'. 
