### PR TITLE
Fixed relative file references for the KEGGDB

### DIFF
--- a/lib/bio/db/kegg/genes.rb
+++ b/lib/bio/db/kegg/genes.rb
@@ -70,12 +70,11 @@
 # 
 
 module Bio
-
-  autoload :KEGGDB,    'bio/db'
-  autoload :Locations, 'bio/location'
-  autoload :Sequence,  'bio/sequence'
-
   require 'bio/db/kegg/common'
+  
+  autoload :KEGGDB,    '../lib/bio/db'
+  autoload :Locations, '../lib/bio/location'
+  autoload :Sequence,  '../lib/bio/sequence'
 
 class KEGG
 


### PR DESCRIPTION
bioruby/test/runner.rb

...was failing with this error:
NameError: uninitialized constant Bio::KEGG::KEGGDB

this is using:
- jruby-1.6.7.2-d19

Simply fixed up the local references for the KEGGDB file
