### PR TITLE
add FastaFormat#first_name method

### DIFF
--- a/lib/bio/db/fasta.rb
+++ b/lib/bio/db/fasta.rb
@@ -68,6 +68,7 @@ module Bio
   # A larger range of methods for dealing with Fasta definition lines can be found in FastaDefline, accessed through the FastaFormat#identifiers method.
   # 
   #   f.entry_id #=> "gi|398365175"
+  #   f.first_name #=> "gi|398365175|ref|NP_009718.3|"
   #   f.definition #=> "gi|398365175|ref|NP_009718.3| Cdc28p [Saccharomyces cerevisiae S288c]"
   #   f.identifiers #=
   #   f.accession #=> "NP_009718"
@@ -90,6 +91,7 @@ module Bio
   #   f.entry #=> ">abc 123 456\nASDF"
   #
   #   f.entry_id #=> "abc"
+  #   f.first_name #=> "abc"
   #   f.definition #=> "abc 123 456"
   #   f.comment #=> nil
   #   f.accession #=> nil
@@ -281,6 +283,21 @@ module Bio
     # Returns locus.
     def locus
       identifiers.locus
+    end
+    
+    # Returns the first name (word) of the definition line - everything
+    # before the first whitespace.
+    #
+    #    >abc def #=> 'abc'
+    #    >gi|398365175|ref|NP_009718.3| Cdc28p [Saccharomyces cerevisiae S288c] #=> 'gi|398365175|ref|NP_009718.3|'
+    #    >abc #=> 'abc'
+    def first_name
+      index = definition.index(/\s/)
+      if index.nil?
+        return @definition
+      else
+        return @definition[0...index]
+      end
     end
 
   end #class FastaFormat

--- a/test/unit/bio/db/test_fasta.rb
+++ b/test/unit/bio/db/test_fasta.rb
@@ -95,7 +95,7 @@ END
     def test_entry_id
       assert_equal('sce:YBR160W', @obj.entry_id)
     end
-
+    
     def test_acc_version
       assert_equal(nil, @obj.acc_version)
     end
@@ -108,6 +108,10 @@ END
     def test_definition
       data = "sce:YBR160W  CDC28, SRM5; cyclin-dependent protein kinase catalytic subunit [EC:2.7.1.-] [SP:CC28_YEAST]"
       assert_equal(data, @obj.definition)
+    end
+    
+    def test_first_name
+      assert_equal('sce:YBR160W', @obj.first_name)
     end
 
     def test_data
@@ -225,7 +229,43 @@ END
     def test_acc_version
       assert_equal('AAV50056.1', @obj.acc_version)
     end
+    
+    def test_first_name
+      assert_equal('gi|55416189|gb|AAV50056.1|', @obj.first_name)
+    end
 
   end # class TestFastaFormat
 
+
+  class TestFastaFirstName < Test::Unit::TestCase
+    def test_first_name1
+      data = ">abc def\nATGC"
+      assert_equal 'abc', Bio::FastaFormat.new(data).first_name
+    end
+    
+    def test_first_name_multi_identifier
+      data = ">gi|398365175|ref|NP_009718.3| Cdc28p [Saccharomyces cerevisiae S288c] #=> 'gi|398365175|ref|NP_009718.3|\nATGCTG"
+      assert_equal 'gi|398365175|ref|NP_009718.3|', Bio::FastaFormat.new(data).first_name
+    end
+    
+    def test_first_name_single_worded_defintion
+      data = ">abc\nATGC"
+      assert_equal 'abc', Bio::FastaFormat.new(data).first_name
+    end
+    
+    def test_no_definition
+      data = ">\nATGC"
+      assert_equal '', Bio::FastaFormat.new(data).first_name
+    end
+    
+    def test_tabbed_defintion
+      data = ">gabc\tdef\nATGC"
+      assert_equal 'gabc', Bio::FastaFormat.new(data).first_name
+    end
+    
+    def test_space_before_first_name
+      data = "> gabcds\tdef\nATGC"
+      assert_equal 'gabcds', Bio::FastaFormat.new(data).first_name
+    end
+  end
 end


### PR DESCRIPTION
One method I wish existed, but didn't appear to before this pull request, is simply to return the first word of the fasta defline, minus any other parsing.

I realise this is rather trivial, but seems to be very often used, e.g. by tab separated BLAST output, but there doesn't appear to be any method for it. Am I overlooking it, or is it too trivial?

I'm not sure if there is a standard way saying "first_name" - I just made that up.
