### PR TITLE
Add 2.0.0 and 2.1.0 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 rvm:
   - 1.9.3
   - 1.8.7
+  - 2.0.0
+  - 2.1.0
 env:
   - TESTOPTS=-v
 gemfile:
@@ -30,6 +32,10 @@ matrix:
     - rvm: 1.9.3
       gemfile: gemfiles/Gemfile.travis-ruby1.9
       env: BIORUBY_RAKE_DEFAULT_TASK=gem-test TESTOPTS=-v
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile.travis-ruby1.9
+    - rvm: 2.1.0
+      gemfile: gemfiles/Gemfile.travis-ruby1.9
     - rvm: jruby-18mode
       gemfile: gemfiles/Gemfile.travis-jruby1.8
       env: TMPDIR=/tmp/bioruby BIORUBY_RAKE_DEFAULT_TASK=tar-integration-test TESTOPTS=-v


### PR DESCRIPTION
I suspect that there's a test failure on Ruby 2.1.0. However, BioRuby doesn't currently have CI for Ruby 2.0.0 or 2.1.0.
