### PR TITLE
non-greedy match for header lines

### DIFF
--- a/lib/bio/appl/fasta/format10.rb
+++ b/lib/bio/appl/fasta/format10.rb
@@ -106,6 +106,11 @@ class Report
       end
     end
 
+    # remove footer comments
+    if footer_start = data.index(">>>///") then
+      data = data[0..(footer_start - 1)]
+    end
+
     # body lines - fasta execution result
     program, *hits = data.split(/\n>>/)
 

--- a/lib/bio/appl/fasta/format10.rb
+++ b/lib/bio/appl/fasta/format10.rb
@@ -94,7 +94,7 @@ class Report
     # header lines - brief list of the hits
     if list_start = data.index("\nThe best scores are") then
       data = data[(list_start + 1)..-1]
-      data.sub!(/(.*)\n\n>>>/m, '')
+      data.sub!(/(.*?)\n\n>>>/m, '')
       @list = $1
     else
       if list_start = data.index(/\n!!\s+/) then


### PR DESCRIPTION
When parsing a FASTA format10 file, I get...

../lib/bio/appl/fasta/format10.rb:114:in `initialize': undefined method`sub!' for nil:NilClass (NoMethodError)

The cause is no hits, because all of the data has been slurped into the @list,
because of a greedy regular expression match in line 97.

data.sub!(/(.*)\n\n>>>/m, '')

I believe the intended behavior is to grab the lines up to the next \n\n>>>,
and assign to @list,
but instead it's grabbing the lines up to the last \n\n>>>,
and assigning to the list,
leaving no data.

For my work, adding the non-greedy operator (.*?) fixed this.

data.sub!(/(.*?)\n\n>>>/m, '') 
