### PR TITLE
Fixes ruby1.8 Travis failure that is because rdoc 4.3.0 requires Ruby…

### DIFF
--- a/gemfiles/Gemfile.travis-jruby1.8
+++ b/gemfiles/Gemfile.travis-jruby1.8
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "rake", "~>10.4"
-gem "rdoc", "~>4.2"
+# rdoc 4.3.0 requires Ruby >= 1.9.3
+gem "rdoc", "~>4.2.0"
 

--- a/gemfiles/Gemfile.travis-ruby1.8
+++ b/gemfiles/Gemfile.travis-ruby1.8
@@ -1,7 +1,8 @@
 source "https://rubygems.org"
 
 gem "rake", "~>10.4"
-gem "rdoc", "~>4.2"
+# rdoc 4.3.0 requires Ruby >= 1.9.3
+gem "rdoc", "~>4.2.0"
 
 gem "xmlparser", "~>0.7.2"
 


### PR DESCRIPTION
I fixed Ruby1.8 and JRuby 1.8 Travis failure.

https://travis-ci.org/bioruby/bioruby/jobs/176727316
> Gem::InstallError: rdoc requires Ruby version >= 1.9.3.
