### PR TITLE
Add code status for Travis to README.rdoc.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -284,6 +284,10 @@ To develop your own plugin, see "Plugins" pages of BioRuby Wiki.
 
 * http://bioruby.open-bio.org/wiki/Plugins
 
+== CODE STATUS
+
+{<img src="https://travis-ci.org/bioruby/bioruby.svg?branch=master" alt="Build Status" />}[https://travis-ci.org/bioruby/bioruby]
+
 == LICENSE
 
 BioRuby can be freely distributed under the same terms as Ruby.


### PR DESCRIPTION
Hi,

I updated README to use Travis build status icon image inspired from below URLs.
Because I thought we were happy to see it easily.

https://github.com/rails/rails/blob/master/README.md
https://github.com/rdoc/rdoc/blob/master/README.rdoc

I was not sure how to set up it for another CI used for bioruby: https://ci.appveyor.com .

Thanks.
