### PR TITLE
fixing Fasta Report parser for fasta36 -m10

### DIFF
--- a/lib/bio/appl/fasta/format10.rb
+++ b/lib/bio/appl/fasta/format10.rb
@@ -94,8 +94,9 @@ class Report
     # header lines - brief list of the hits
     if list_start = data.index("\nThe best scores are") then
       data = data[(list_start + 1)..-1]
-      data.sub!(/(.*)\n\n>>>/m, '')
+      data.sub!(/(.*?)\n\n>>>/m, '')
       @list = $1
+      data.sub!(/>>><<<(.*)$/m, '')
     else
       if list_start = data.index(/\n!!\s+/) then
         data = data[list_start..-1]


### PR DESCRIPTION
Hi BioRubyers!

These small changes will fix the FASTA alignment Report parser - tested on reports from fasta36 (single sequence and multi-sequence queries both work), format -m10 (the default, and only format that BioRuby supports)

Is it possible to get these into the Gem soon?  It would be nice if this example worked for my course :-)

Cheers!

Mark

