### PR TITLE
Add https requests + fix blast query

### DIFF
--- a/lib/bio/appl/blast/genomenet.rb
+++ b/lib/bio/appl/blast/genomenet.rb
@@ -211,7 +211,7 @@ module Bio::Blast::Remote
       end
 
       begin
-        http = Bio::Command.new_http(host)
+        http = Bio::Command.new_https(host)
         http.open_timeout = 300
         http.read_timeout = 600
         result = Bio::Command.http_post_form(http, path, form)

--- a/lib/bio/command.rb
+++ b/lib/bio/command.rb
@@ -791,6 +791,20 @@ module Command
     end
   end
 
+  def new_https(address, port = 443)
+    uri = URI.parse("https://#{address}:#{port}")
+    # Note: URI#find_proxy is an unofficial method defined in open-uri.rb.
+    # If the spec of open-uri.rb would be changed, we should change below.
+    if proxyuri = uri.find_proxy then
+      raise 'Non-HTTP proxy' if proxyuri.class != URI::HTTP
+      Net::HTTP.new(address, port, proxyuri.host, proxyuri.port)
+    else
+      connection = Net::HTTP.new(address, port)
+      connection.use_ssl = true
+      connection
+    end
+  end
+
   # Same as:
   #  http = Net::HTTP.new(...); http.post_form(path, params)
   # and 


### PR DESCRIPTION
**TL;DR** Fix for issue #123. 

[www.geneomenet.jp](www.geneomenet.jp) started to use `https` and requests were failing when using `Net::HTTP` to make the requests. The issue is fixed by adding a new `new_https` method in `command.rb` that forces `use_ssl` on the connection.