### PR TITLE
update TogoWS documentation. genbank -> ncbi-nucleotide

### DIFF
--- a/lib/bio/io/togows.rb
+++ b/lib/bio/io/togows.rb
@@ -107,14 +107,14 @@ module Bio
     # 
     # For light users, class methods can be used.
     #
-    #   print Bio::TogoWS::REST.entry('genbank', 'AF237819')
+    #   print Bio::TogoWS::REST.entry('ncbi-nucleotide', 'AF237819')
     #   print Bio::TogoWS::REST.search('uniprot', 'lung cancer')
     #
     # For heavy users, an instance of the REST class can be created, and
     # using the instance is more efficient than using class methods.
     #
     #   t = Bio::TogoWS::REST.new
-    #   print t.entry('genbank', 'AF237819')
+    #   print t.entry('ncbi-nucleotide', 'AF237819')
     #   print t.search('uniprot', 'lung cancer')
     #
     # == References
@@ -222,9 +222,9 @@ module Bio
       #
       # Example:
       #   t = Bio::TogoWS::REST.new
-      #   kuma = t.entry('genbank', 'AF237819')
+      #   kuma = t.entry('ncbi-nucleotide', 'AF237819')
       #   # multiple IDs at a time
-      #   misc = t.entry('genbank', [ 'AF237819', 'AF237820' ])
+      #   misc = t.entry('ncbi-nucleotide', [ 'AF237819', 'AF237820' ])
       #   # with format change
       #   p53 = t.entry('uniprot', 'P53_HUMAN', 'fasta')
       #
@@ -366,7 +366,7 @@ module Bio
       # Access to the TogoWS by using GET method.
       #
       # Example 1:
-      #   get('entry', 'genbank', AF209156')
+      #   get('entry', 'ncbi-nucleotide', AF209156')
       # Example 2:
       #   get('search', 'uniprot', 'lung cancer')
       #

--- a/sample/test_restriction_enzyme_long.rb
+++ b/sample/test_restriction_enzyme_long.rb
@@ -14,7 +14,7 @@ require 'test/unit'
 require 'benchmark'
 require 'bio'
 
-entry = Bio::TogoWS::REST.entry('genbank', 'BA000007.2')
+entry = Bio::TogoWS::REST.entry('ncbi-nucleotide', 'BA000007.2')
 EcoliO157H7Seq = Bio::GenBank.new(entry).naseq.freeze
 
 module TestRestrictionEnzymeAnalysisCutLong


### PR DESCRIPTION
Hello.

TogoWS does not seem to have an item "genbank" anymore.
In this pull request, I changed "genbank" to "ncbi-nucletide".
I am pleased if you can check it.

Thank you.