### PR TITLE
Fix typos: Retrun -> Return

### DIFF
--- a/lib/bio/appl/iprscan/report.rb
+++ b/lib/bio/appl/iprscan/report.rb
@@ -83,7 +83,7 @@ module Bio
         yield Bio::Iprscan::Report.parse_raw_entry(entry) if entry != ''
       end
     
-      # Parser method for a raw formated entry. Retruns a Bio::Iprscan::Report 
+      # Parser method for a raw formated entry. Returns a Bio::Iprscan::Report 
       # object.
       def self.parse_raw_entry(str)
         report = self.new
@@ -113,7 +113,7 @@ module Bio
 
 
 
-      # Parser method for a xml formated entry. Retruns a Bio::Iprscan::Report 
+      # Parser method for a xml formated entry. Returns a Bio::Iprscan::Report 
       # object.
 #      def self.parse_xml(str)
 #      end
@@ -196,7 +196,7 @@ module Bio
         end
       end
 
-      # Parser method for a pseudo-txt formated entry. Retruns a Bio::Iprscan::Report 
+      # Parser method for a pseudo-txt formated entry. Returns a Bio::Iprscan::Report 
       # object.
       # 
       # == Usage

--- a/lib/bio/appl/sosui/report.rb
+++ b/lib/bio/appl/sosui/report.rb
@@ -78,7 +78,7 @@ module Bio
         # Returns aRng of transmembrane helix
         attr_reader :range
         
-        # Retruns ``PRIMARY'' or ``SECONDARY'' of helix.
+        # Returns ``PRIMARY'' or ``SECONDARY'' of helix.
         attr_reader :grade
 
         # Returns the sequence. of transmembrane helix. 

--- a/lib/bio/db/embl/uniprotkb.rb
+++ b/lib/bio/db/embl/uniprotkb.rb
@@ -174,7 +174,7 @@ class UniProtKB < EMBLDB
   #
   # http://www.uniprot.org/docs/sp_news.htm
   def parse_DE_line_rel14(str)
-    # Retruns if it is not the new format since Rel.14
+    # Returns if it is not the new format since Rel.14
     return nil unless /^DE   (RecName|AltName|SubName)\: / =~ str
     ret = []
     cur = nil

--- a/lib/bio/db/go.rb
+++ b/lib/bio/db/go.rb
@@ -193,7 +193,7 @@ class GO
     # Delimiter
     RS = DELIMITER 
 
-    # Retruns an Array of parsed gene_association flatfile.
+    # Returns an Array of parsed gene_association flatfile.
     # Block is acceptable.  
     def self.parser(str)
       if block_given?
@@ -226,7 +226,7 @@ class GO
     # Returns Db_Reference variable.
     attr_reader :db_reference      # -> []
 
-    # Retruns Evidence code variable.
+    # Returns Evidence code variable.
     attr_reader :evidence
 
     # Returns the entry is associated with this value.

--- a/lib/bio/tree.rb
+++ b/lib/bio/tree.rb
@@ -605,7 +605,7 @@ module Bio
     end
 
     # Gets path from node1 to node2.
-    # Retruns an array of nodes, including node1 and node2.
+    # Returns an array of nodes, including node1 and node2.
     # If node1 and/or node2 do not exist, IndexError is raised.
     # If node1 and node2 are not connected, NoPathError is raised.
     # The result is unspecified for cyclic trees.


### PR DESCRIPTION
Found very common typo, Retrun, and replaced them with Return.